### PR TITLE
Fix uninitialised values

### DIFF
--- a/src/EqMaster/EqMasterCommon.hpp
+++ b/src/EqMaster/EqMasterCommon.hpp
@@ -120,7 +120,8 @@ class TrackEq {
 		trackGainSlewer.setRiseFall(antipopSlewDb);
 		
 		// the following are just set here to dummy values since there are test and sets in their initializations further below, and this is just to get rid of uninit warning, good values will be set in init()'s onReset()
-		// trackActive = false;
+		trackActive = false;
+		dirty = 0xF;
 		bandActive = simd::float_4(0.0f);
 		freq = simd::float_4(0.0f);
 		gain = simd::float_4(0.0f);

--- a/src/ShapeMaster/Channel.cpp
+++ b/src/ShapeMaster/Channel.cpp
@@ -95,7 +95,6 @@ void Channel::onReset(bool withParams) {
 void Channel::resetNonJson() {
 	sampleTime = 1.0 / (double)APP->engine->getSampleRate();
 	xover.reset();
-	setCrossoverCutoffFreq();
 	// lastCrossoverParamWithCv; automatically set in setCrossoverCutoffFreq()
 	hpFilter.reset();
 	setHPFCutoffSqFreq(hpfCutoffSqFreq);	
@@ -119,6 +118,7 @@ void Channel::resetNonJson() {
 	warpPhaseResponseAmountCvConnected = false;
 	xoverSlewWithCv = simd::float_4(paCrossover->getValue(), paHigh->getValue(), paLow->getValue(), paSlew->getValue());
 	xoverSlewCvConnected = false;
+	setCrossoverCutoffFreq();
 }
 
 

--- a/src/ShapeMaster/PresetAndShapeManager.hpp
+++ b/src/ShapeMaster/PresetAndShapeManager.hpp
@@ -35,9 +35,9 @@ class PresetAndShapeManager {
 	Channel* channelDirtyCacheSrc;
 	
 	// worker
-	int workType[8] = {WT_PREV_PRESET};// this value is not used
+	int workType[8] = {};// this value is not used
 	bool withHistory[8];
-	int8_t requestWork[8] = {WS_NONE};
+	int8_t requestWork[8] = {};
 	std::condition_variable cv;// https://thispointer.com//c11-multithreading-part-7-condition-variables-explained/
 	std::mutex mtx;
 	std::thread worker;// http://www.cplusplus.com/reference/thread/thread/thread/


### PR DESCRIPTION
As reported by valgrind.

The one in `EqMasterCommon.hpp` was commented out, were there issues with it before?
I added it back and enabled the same thing a call to `setTrackActive` would do, that is, tag all tracks as dirty.

For the last one, it is a common C vs C++ mistake.
For C, this code initializes an array:

```
int x[5] = {1}; // all values are 1
```

On C++ though this same code will only set the first value, the others will be undefined.
We need to use `= {}` syntax (without a containing value) in order to initialize all to zero.

valgrind logs:

```
==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1B5286A: TrackEq::setTrackActive(bool) (EqMasterCommon.hpp:191)
==869036==    by 0x1B5200E: TrackEq::onReset() (EqMasterCommon.hpp:151)
==869036==    by 0x1B51EB4: TrackEq::init(int, float, unsigned int*) (EqMasterCommon.hpp:136)
==869036==    by 0x1B6043D: EqMaster::onReset() (EqMaster.cpp:190)
==869036==    by 0x1B5FC7D: EqMaster::EqMaster() (EqMaster.cpp:153)
==869036==    by 0x1B76846: rack::CardinalPluginModel<EqMaster, EqMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1B7683B: rack::CardinalPluginModel<EqMaster, EqMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7214F40: __powf_fma (e_powf.c:154)
==869036==    by 0x6B2826: std::pow(float, float) (cmath:389)
==869036==    by 0x1C12076: Channel::setCrossoverCutoffFreq() (Channel.hpp:235)
==869036==    by 0x23C0FB1: Channel::resetNonJson() (Channel.cpp:102)
==869036==    by 0x23C0F17: Channel::onReset(bool) (Channel.cpp:95)
==869036==    by 0x1C06DC0: ShapeMaster::onReset() (ShapeMaster.cpp:106)
==869036==    by 0x1C06272: ShapeMaster::ShapeMaster() (ShapeMaster.cpp:84)
==869036==    by 0x1C2577E: rack::CardinalPluginModel<ShapeMaster, ShapeMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C25773: rack::CardinalPluginModel<ShapeMaster, ShapeMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x7215182: __powf_fma (e_powf.c:160)
==869036==    by 0x6B2826: std::pow(float, float) (cmath:389)
==869036==    by 0x1C12076: Channel::setCrossoverCutoffFreq() (Channel.hpp:235)
==869036==    by 0x23C0FB1: Channel::resetNonJson() (Channel.cpp:102)
==869036==    by 0x23C0F17: Channel::onReset(bool) (Channel.cpp:95)
==869036==    by 0x1C06DC0: ShapeMaster::onReset() (ShapeMaster.cpp:106)
==869036==    by 0x1C06272: ShapeMaster::ShapeMaster() (ShapeMaster.cpp:84)
==869036==    by 0x1C2577E: rack::CardinalPluginModel<ShapeMaster, ShapeMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C25773: rack::CardinalPluginModel<ShapeMaster, ShapeMasterWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==885280== Thread 12:
==885280== Conditional jump or move depends on uninitialised value(s)
==885280==    at 0x23F8BF5: PresetAndShapeManager::file_worker() (PresetAndShapeManager.cpp:215)
==885280==    by 0x23FE292: void std::__invoke_impl<void, void (PresetAndShapeManager::*)(), PresetAndShapeManager*>(std::__invoke_memfun_deref, void (PresetAndShapeManager::*&&)(), PresetAndShapeManager*&&) (invoke.h:74)
==885280==    by 0x23FE1E4: std::__invoke_result<void (PresetAndShapeManager::*)(), PresetAndShapeManager*>::type std::__invoke<void (PresetAndShapeManager::*)(), PresetAndShapeManager*>(void (PresetAndShapeManager::*&&)(), PresetAndShapeManager*&&) (invoke.h:96)
==885280==    by 0x23FE144: void std::thread::_Invoker<std::tuple<void (PresetAndShapeManager::*)(), PresetAndShapeManager*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (std_thread.h:253)
==885280==    by 0x23FE0F9: std::thread::_Invoker<std::tuple<void (PresetAndShapeManager::*)(), PresetAndShapeManager*> >::operator()() (std_thread.h:260)
==885280==    by 0x23FE0D9: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (PresetAndShapeManager::*)(), PresetAndShapeManager*> > >::_M_run() (std_thread.h:211)
==885280==    by 0x775B2C2: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==885280==    by 0x795FB42: start_thread (pthread_create.c:442)
==885280==    by 0x79F0BB3: clone (clone.S:100)
==885280==  Uninitialised value was created by a heap allocation
==885280==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==885280==    by 0x1C25925: rack::CardinalPluginModel<ShapeMaster, ShapeMasterWidget>::createModule() (helpers.hpp:52)
==885280==    by 0x6B39FB: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:487)
==885280==    by 0x6CA11E: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==885280==    by 0x6C638C: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==885280==    by 0x6C65D0: main (DistrhoPluginJACK.cpp:963)
==885280==
```